### PR TITLE
Update search to use lowercase for query and name

### DIFF
--- a/dekstop_frontend/src/Pages/home/Home.jsx
+++ b/dekstop_frontend/src/Pages/home/Home.jsx
@@ -48,7 +48,9 @@ function Home() {
 		if (!queryValue) {
 			return items;
 		}
-		return items.filter((item) => item.name.includes(queryValue));
+		return items.filter((item) =>
+			item.name.toLowerCase().includes(queryValue.toLowerCase())
+		);
 	}
 	const filteredServers = getFilteredServers(query, servers);
 


### PR DESCRIPTION
- search filter was not comparing character casing previously
- implemented method to compares query and server name values at lower case